### PR TITLE
Bugfix duplicate change game button

### DIFF
--- a/main.js
+++ b/main.js
@@ -131,14 +131,14 @@ function launchClassic() {
     '<img class="selector-image" id="Paper" src="./assets/Paper.png">' +
     '<img class="selector-image" id="Scissors" src="./assets/Scissors.png">';
   resultSection.innerText = "Choose your fighter!"
-  showChangeGameButton();
+  if (!changeGameButtonCreated) {
+    showChangeGameButton();
+  }
 }
 
 function delayLaunchClassic() {
   setTimeout(function() {
-    if (!changeGameButtonCreated) {
-      launchClassic();
-    }
+     launchClassic();
   }, 2000);
 } // this will need to be dynamic and work for difficult as well as classic.
 


### PR DESCRIPTION
The "Change Game" button was originally being duplicated every time the game state was reset.

I fixed this by adding a conditional and global variable to check if the button has been created yet. 

There may be a better way to do this, but I need to continue for now. 